### PR TITLE
docs: add shared/subscribed calendar setup for CalDAV sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,24 @@ zele cal respond <event-id>       # accept/decline
 zele cal freebusy                 # check availability
 ```
 
+#### Shared / subscribed calendars
+
+Zele uses Google CalDAV for calendar access. By default, Google only syncs calendars you **own** over CalDAV — shared or subscribed calendars (e.g. a partner's calendar) won't appear in `zele cal list` even after accepting the share invitation.
+
+To fix this, visit Google's CalDAV sync settings and enable the shared calendar:
+
+1. Open **https://www.google.com/calendar/syncselect** (logged in as the account you use with zele)
+2. Check the box next to any shared calendar you want to access
+3. Click **Save**
+
+After that, `zele cal list` will show the shared calendar and you can query it:
+
+```bash
+zele cal events --calendar "other-person@gmail.com" --week
+```
+
+> **Why is this needed?** Google's CalDAV endpoint only exposes calendars marked for sync (originally designed for mobile device sync). The Google Calendar web UI uses a different internal API, so calendars visible there may not appear via CalDAV until explicitly enabled at the sync settings page.
+
 ### Attachments
 
 ```bash


### PR DESCRIPTION
## Problem

Shared or subscribed Google calendars (e.g. a partner's calendar) don't appear in `zele cal list` even after accepting the share invitation. This is because Google's CalDAV endpoint only exposes calendars explicitly marked for sync — a setting originally designed for mobile device sync.

## Solution

Added a section to the README explaining how to enable shared calendars for CalDAV access via https://www.google.com/calendar/syncselect, with a brief explanation of why this is needed.

## Steps to reproduce the issue

1. Have someone share their Google Calendar with you
2. Accept the share invitation
3. Run `zele cal list` — the shared calendar won't appear
4. Visit https://www.google.com/calendar/syncselect and check the shared calendar
5. Run `zele cal list` again — now it appears